### PR TITLE
Fix bug when use AppCompatActivity the ClassLoader conflict problem

### DIFF
--- a/EzXHelper/src/main/java/com/github/kyuubiran/ezxhelper/utils/parasitics/FixedClassLoader.kt
+++ b/EzXHelper/src/main/java/com/github/kyuubiran/ezxhelper/utils/parasitics/FixedClassLoader.kt
@@ -1,13 +1,11 @@
 package com.github.kyuubiran.ezxhelper.utils.parasitics
 
-import android.content.Context
-
 class FixedClassLoader(
     private val mModuleClassLoader: ClassLoader,
     private val mHostClassLoader: ClassLoader
 ) : ClassLoader(mBootstrap) {
     companion object {
-        private val mBootstrap: ClassLoader = Context::class.java.classLoader!!
+        private val mBootstrap: ClassLoader = ActivityHelper::class.java.classLoader!!
     }
 
     override fun loadClass(name: String, resolve: Boolean): Class<*> {


### PR DESCRIPTION
不应该使用 `Context::class.java.classloader` 去装载模块的 `ClassLoader`，会导致重新继承于 `AppCompatActivity` 的寄生模块 Activity 发生 class-cast 异常，经过反复测试证实 ClassLoader 是错的，通过 `Context::class.java.classloader` 拿到的其实是宿主的 ClassLoader，所以目前修改为获取了一个比较接近的当前包名下面的 Class 拿到 ClassLoader，确保 ClassLoader 正确装载为模块。