### PR TITLE
Disable `android.useAndroidX`

### DIFF
--- a/.github/workflows/kdoc.yml
+++ b/.github/workflows/kdoc.yml
@@ -3,7 +3,7 @@ name: Build KDoc
 on:
   push:
     branches: [2.x]
-    workflow_dispatch:
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -12,30 +12,33 @@ permissions:
 
 jobs:
   build:
+    name: Build KDoc
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
 
     steps:
       - name: Clone master branch
-        uses: actions/checkout@v3.5.2
+        uses: actions/checkout@v4
 
       - name: Prepare Java 17
-        uses: actions/setup-java@v3.11.0
+        uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: adopt
 
       - name: Cache Gradle packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('/*.gradle') }}-${{ hashFiles('/*.gradle.kts') }}
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('build.gradle') }}
 
       - name: Build KDoc
-        run: |
-          ./gradlew :EzXHelper:dokkaHtml
+        run: ./gradlew :EzXHelper:dokkaHtml
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./EzXHelper/build/dokka/html
 
@@ -49,4 +52,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app"s APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
-android.useAndroidX=true
+#android.useAndroidX=true
 android.nonTransitiveRClass=true
 kotlin.code.style=official
 


### PR DESCRIPTION
This is enforced even on repositories that don't actually use AndroidX, so to avoid that problem.